### PR TITLE
chore: remove myself the "Main Collaborator" role

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -3,6 +3,3 @@
 * [Inon Shkedy](mailto:inon.shkedy@owasp.org)
 * [Roshan Piyush](mailto:roshan.piyush@owasp.org) 
 
-#### Main Collaborator
-
-* [Paulo Silva](mailto:paulo.silva@owasp.org)


### PR DESCRIPTION
I prefer to stand as a regular contributor to the crAPI project as I do
for a few other OWASP projects. So far, my contributions to the project do not
deserve any special title or role.